### PR TITLE
Compile with Coq 8.5

### DIFF
--- a/RelDefinitions.v
+++ b/RelDefinitions.v
@@ -1,5 +1,6 @@
 Require Export Coq.Program.Basics.
 Require Export Coq.Classes.Morphisms.
+Require Setoid.
 
 (** * Prerequisites *)
 

--- a/Relators.v
+++ b/Relators.v
@@ -103,7 +103,7 @@ Notation "∀ - : 'rel' , FE" := (forall_pointwise_rel (fun _ => FE))
   (at level 200).
 
 Notation "∀ - : 'rel' v , FE" := (forall_pointwise_rel (fun v => FE))
-  (at level 200, a at level 0).
+  (at level 200, v at level 0).
 
 Global Instance forall_pointwise_rintro {V FV1 FV2} (FE: forall v, rel _ _) f g:
   RIntro


### PR DESCRIPTION
Hi,

These two commits allow compiling your code with Coq 8.5 without breaking the compatibility with 8.4.
I have put detailed explanations about the changes in the commit messages.

Cheers,
Théo

PS: you could be interested to have a look at my work (https://github.com/Zimmi48/transfer - more particularly the library folder). I am still looking at yours to understand better what you have done and how I could take advantage of it.

PPS: your work is unlicensed. Please add a LICENSE file to your repository so that reuse becomes possible (without action on your part, the default is full copyright and in that case nobody is able to use your work, even as a library). I would advise a semi-permissive "library" license (my preferred one is [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/FAQ/), but there is also LGPL v3 or v2.1) or a fully permissive license (MIT).
